### PR TITLE
[Yang] [DPB] Change port to leafref also for VOQ - fix #19105 & #19133

### DIFF
--- a/src/sonic-yang-models/yang-models/sonic-buffer-queue.yang
+++ b/src/sonic-yang-models/yang-models/sonic-buffer-queue.yang
@@ -90,11 +90,9 @@ module sonic-buffer-queue {
                 }
 
                 leaf port {
-                    type string {
-                        length 1..128;
+                    type leafref {
+                        path /prt:sonic-port/prt:PORT/prt:PORT_LIST/prt:name;
                     }
-
-                    description "port name.";
                 }
 
                 leaf qindex {


### PR DESCRIPTION
Fix for DPB - VOQ_BUFFER_QUEUE_LIST retained entries for deleted ports.
bugs #19105 #19133 
#### Why I did it
Make port breakout flow to delete also these entries when port is deleted.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Change "port" (key) in sonic-buffer-queue.yang for VOQ to also be leafref

#### How to verify it
Test scenario in bugs.
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

